### PR TITLE
[patch] 使っていないライブラリをコメントアウト

### DIFF
--- a/.github/workflows/auto_version_up.yml
+++ b/.github/workflows/auto_version_up.yml
@@ -78,4 +78,4 @@ jobs:
                 GH_TOKEN: ${{ github.token }}
               run: |
                 NEW_VERSION="${{ steps.auto_version_up.outputs.NEW_VERSION }}"
-                echo -e "# Version up to v${{ NEW_VERSION }}\nTriggered by ${{ github.event.pull_request.url }}" | gh pr create --title "Version up to v${NEW_VERSION}" --base ${{ github.event.pull_request.head.ref }} --head version/v${NEW_VERSION} --body-file=-
+                echo -e "# Version up to v$NEW_VERSION\nTriggered by ${{ github.event.pull_request.url }}" | gh pr create --title "Version up to v${NEW_VERSION}" --base ${{ github.event.pull_request.head.ref }} --head version/v${NEW_VERSION} --body-file=-

--- a/jmlog/lib/main.dart
+++ b/jmlog/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:jmlog/presentation/views/app.dart';
 
-import 'package:firebase_auth/firebase_auth.dart';
+// import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'firebase_options.dart';
 

--- a/jmlog/pubspec.yaml
+++ b/jmlog/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.1.1+3
+version: 0.1.2+4
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
firebase_authはまだ使わないかつ、テストが落ちてしまうので一度コメントアウトで対応